### PR TITLE
Lose pip deps version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pip~=22.2
 voila~=0.3
 voila-osscar-template~=0.3
 matplotlib~=3.5


### PR DESCRIPTION
Hi @dou-du, can you quickly look at this? It makes no sense to have such a strict `pip` version limit. It prevents AiiDAlab to install the widget. 