### PR TITLE
Extension the band structure plot to cover the fat bands use cases

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -20,6 +20,7 @@ def bands_schema():
 def test_valid_bands_default(bands_schema):
     data = {
         "fermi_level": -7.0,
+        "color-partial bands (only one field is needed for this case.)": "blue",
         "path": [["GAMMA", "Y"], ["Y", "C_0"], ["SIGMA_0", "GAMMA"]],
         "paths": [
             {
@@ -31,6 +32,11 @@ def test_valid_bands_default(bands_schema):
                     [1.0, 1.1, 1.2],
                     [2.0, 2.1, 2.2],
                 ],
+                "highlight (thickness of the bands) (optional)": [
+                    [0.0, 0.1, 0.2],
+                    [1.0, 1.1, 1.2],
+                    [2.0, 2.1, 2.2],
+                ]
                 "x": [0.0, 1.0, 2.0],
             },
             {


### PR DESCRIPTION
This is the part we are going to add after the meeting with Carlo and Junfeng. The goal is to extend the widget so the fat bands (see below) can be plotted. 

![image](https://user-images.githubusercontent.com/8831685/221143785-0dfb9ea8-c3ca-406e-a21d-ced4c1c05e99.png)
